### PR TITLE
Half-way to python3

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+source = turq
+
+[report]
+omit = 
+    tests*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,0 @@
-[run]
-source = turq
-
-[report]
-omit = 
-    tests*

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ build
 dist
 docs/_build
 MANIFEST
+.tox
+.coverage*
+.idea/

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,18 @@
 # -*- coding: utf-8 -*-
 
 import distutils.core
+import ast
+import re
 
-import turq
+def find_version(path):
+    _version_re = re.compile(r'__version__\s+=\s+(.*)')
+    with open(path, 'rb') as f:
+        return str(ast.literal_eval(_version_re.search(
+            f.read().decode('utf-8')).group(1)))
 
 distutils.core.setup(
     name='turq',
-    version=turq.__version__,
+    version=find_version('turq.py'),
     description='Mock HTTP server',
     long_description=open('README.rst').read(),
     author='Vasiliy Faronov',

--- a/tests.py
+++ b/tests.py
@@ -6,6 +6,7 @@ import gzip
 from six.moves import http_client
 import socket
 import subprocess
+from signal import SIGINT
 import time
 import unittest
 from six.moves.urllib.parse import urlencode
@@ -20,12 +21,12 @@ class TurqTestCase(unittest.TestCase):
             # exec prevents the shell from spawning a subprocess
             # which then fails to terminate.
             # http://stackoverflow.com/questions/4789837/
-            'exec python turq.py --host 127.0.0.1', shell=True,
+            'exec coverage run turq.py --host 127.0.0.1', shell=True,
             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         time.sleep(0.5)
 
     def tearDown(self):
-        self.proc.kill()
+        self.proc.send_signal(SIGINT)
         self.proc.wait()
         time.sleep(0.2)
     

--- a/tests.py
+++ b/tests.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 
-from cStringIO import StringIO
+from six import StringIO
 from datetime import datetime, timedelta
 import gzip
-import httplib
+from six.moves import http_client
 import socket
 import subprocess
 import time
 import unittest
-import urllib
+from six.moves.urllib.parse import urlencode
 
 socket.setdefaulttimeout(5)
 
@@ -20,17 +20,17 @@ class TurqTestCase(unittest.TestCase):
             # exec prevents the shell from spawning a subprocess
             # which then fails to terminate.
             # http://stackoverflow.com/questions/4789837/
-            'exec python turq.py', shell=True,
+            'exec python turq.py --host 127.0.0.1', shell=True,
             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        time.sleep(0.2)
-    
+        time.sleep(0.5)
+
     def tearDown(self):
         self.proc.kill()
         self.proc.wait()
         time.sleep(0.2)
     
     def request(self, method, path, headers=None, body=None):
-        conn = httplib.HTTPConnection('127.0.0.1', 13085)
+        conn = http_client.HTTPConnection('127.0.0.1', 13085)
         conn.request(method, path, body, headers or {})
         resp = conn.getresponse()
         return resp, resp.read()
@@ -39,9 +39,9 @@ class TurqTestCase(unittest.TestCase):
         info, data = self.request(
             'POST', '/+turq/',
             {'Content-Type': 'application/x-www-form-urlencoded'},
-            urllib.urlencode({'code': code})
+            urlencode({'code': code})
         )
-        self.assertEqual(info.status, httplib.OK)
+        self.assertEqual(info.status, http_client.OK)
         if check:
             self.assert_('>okay<' in data)
         return info, data
@@ -223,7 +223,7 @@ class TurqTestCase(unittest.TestCase):
         info, data = self.request('GET', '/')
         self.assertEqual(data, 'fine!')
         info, data = self.request('DELETE', '/')
-        self.assertEqual(info.status, httplib.METHOD_NOT_ALLOWED)
+        self.assertEqual(info.status, http_client.METHOD_NOT_ALLOWED)
     
     def test_gzip(self):
         self.install("path().text('compress this!').gzip()")

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,16 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py26, py27, py33, py34
+
+[testenv]
+commands =
+    python tests.py
+    coverage report
+
+deps =
+    six
+    coverage

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py33, py34
+envlist = py26, py27
 
 [testenv]
 commands =

--- a/turq.py
+++ b/turq.py
@@ -702,16 +702,19 @@ class TurqHandler(BaseHTTPServer.BaseHTTPRequestHandler):
 
 
 def main():
-    parser = OptionParser(usage='usage: %prog [-p PORT]')
+    parser = OptionParser(usage='usage: %prog [-p PORT] [--host HOST]')
     parser.add_option('-p', '--port', dest='port', type='int',
                       default=DEFAULT_PORT,
                       help='listen on PORT', metavar='PORT')
+    parser.add_option('', '--host', dest='host',
+                      default=DEFAULT_HOST,
+                      help='listen on HOST', metavar='HOST')
     options, args = parser.parse_args()
     
-    server = BaseHTTPServer.HTTPServer(('0.0.0.0', options.port), TurqHandler)
+    server = BaseHTTPServer.HTTPServer((options.host, options.port), TurqHandler)
     sys.stderr.write('Listening on port %d\n' % server.server_port)
     sys.stderr.write('Try http://%s:%d/+turq/\n' %
-                     (socket.getfqdn(), server.server_port))
+                     (options.host == DEFAULT_HOST and socket.getfqdn() or options.host, server.server_port))
     try:
         server.serve_forever()
     except KeyboardInterrupt:


### PR DESCRIPTION
Here is "almost python3-ready" version. 
It runs on python3, but does not work properly on python3 yet.

Major changes:
- `exec in` statement removed, now uses `exec` function  
-  `six` used for imports
- tox configuration added to support multi-environment testing

Minor changes:
- `--host` argument added to prevent warnings on mac os
- version detection method in setup.py changed
- using `coverage` in tests  

All tests works well on py2.
So I suppose it can be merged to master branch as a first step for future py3 support. 
